### PR TITLE
Restore mtimes after checking out to avoid re-synching stuff to S3 unnecessarily

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,7 +9,13 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - run: |
+          sudo apt-get update -y
+          sudo apt-get install -y git-restore-mtime
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git restore-mtime
       - uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: >-


### PR DESCRIPTION
Fixes #2 

This is due to the fact that the S3 cli uses mtimes to determine if files need to be uploaded or not.

> A local file will require uploading if the size of the local file is different than the size of the s3 object, the last modified time
of the local file is newer than the last modified time of the s3 object, or the local file does not exist under the specified
bucket and prefix.