### PR TITLE
Clean up readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ consumed by the [ember-api-docs frontend](https://github.com/ember-learn/ember-a
 The content in this repository is generated via
 [ember-jsonapi-docs](https://github.com/ember-learn/ember-jsonapi-docs). To build new versions of the files for this repository follow the instructions in `ember-jsonapi-docs`'s [README](https://github.com/ember-learn/ember-jsonapi-docs).
 
-If you want to see how this content will look in the `ember-api-docs` frontend in your local environment follow [these instructions](https://github.com/ember-learn/ember-jsonapi-docs#optional-view-the-generated-docs-in-a-web-app).
+If you want to see how this content will look in the `ember-api-docs` frontend in your local environment follow [these instructions](https://github.com/ember-learn/ember-api-docs).

--- a/README.md
+++ b/README.md
@@ -3,28 +3,10 @@
 ![Sync with S3](https://github.com/ember-learn/ember-api-docs-data/workflows/Sync%20with%20S3/badge.svg)
 
 The content of this repository is synced to the `s3://api-docs.emberjs.com`
-S3 bucket via a [GitHub Action](./github/workflows/sync.yml). The data is
-consumed by the [API Docs Viewer](https://github.com/ember-learn/ember-api-docs).
+S3 bucket via a [GitHub Action](./github/workflows/sync.yml). That data is
+consumed by the [ember-api-docs frontend](https://github.com/ember-learn/ember-api-docs).
 
-These files are auto-generated via
-https://github.com/ember-learn/ember-jsonapi-docs
+The content in this repository is generated via
+[ember-jsonapi-docs](https://github.com/ember-learn/ember-jsonapi-docs). To build new versions of the files for this repository follow the instructions in `ember-jsonapi-docs`'s [README](https://github.com/ember-learn/ember-jsonapi-docs).
 
-## Previewing these docs in the front end
-
-If you want to see how these docs will look in the
-front end app:
-
-```
-git clone https://github.com/ember-learn/ember-api-docs-data
-cd ember-api-docs-data
-yarn install
-yarn serve
-
-cd ..
-git clone https://github.com/ember-learn/ember-api-docs
-cd ember-api-docs-data
-yarn install
-yarn start:local
-```
-
-The JSON files will be served at `http://localhost:5050` and the app can be viewed in the browser at [http://localhost:4200]().
+If you want to see how this content will look in the `ember-api-docs` frontend in your local environment follow [these instructions](https://github.com/ember-learn/ember-jsonapi-docs#optional-view-the-generated-docs-in-a-web-app).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # Ember API Docs Data
 
-![Sync with S3](https://github.com/ember-learn/ember-api-docs-data/workflows/Sync%20with%20S3/badge.svg)
-
-The content of this repository is synced to the `s3://api-docs.emberjs.com`
-S3 bucket via a [GitHub Action](./github/workflows/sync.yml). That data is
-consumed by the [ember-api-docs frontend](https://github.com/ember-learn/ember-api-docs).
-
 The content in this repository is generated via
 [ember-jsonapi-docs](https://github.com/ember-learn/ember-jsonapi-docs). To build new versions of the files for this repository follow the instructions in `ember-jsonapi-docs`'s [README](https://github.com/ember-learn/ember-jsonapi-docs).
 
-If you want to see how this content will look in the `ember-api-docs` frontend in your local environment follow [these instructions](https://github.com/ember-learn/ember-api-docs).
+That content is consumed by the [`ember-api-docs` frontend](https://github.com/ember-learn/ember-api-docs). If you want to see how this content will look in the `ember-api-docs` frontend in your local environment follow [these instructions](https://github.com/ember-learn/ember-api-docs).


### PR DESCRIPTION
- Some things weren't accurate anymore, so this cleans that up
- There are too many places that describe how to spin up a local environment so this moves to pointing to the instructions in ember-jsonapi-docs